### PR TITLE
shrink-go: create image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Pre-requisites
 --------------
 * [Docker](https://docs.docker.com/engine/installation/)
 
+Images
+------
+| Name                            | Description                                                                                           |
+|---------------------------------|-------------------------------------------------------------------------------------------------------|
+| [mandrean/shrink-go](shrink-go) | Build image for compiling & shrinking statically linked Go binaries into their smallest possible size |
+
+
 Maintainers
 -----------
 * Sebastian Mandrean (<sebastian@0x.se>)

--- a/shrink-go/Dockerfile
+++ b/shrink-go/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.9-alpine3.6
+
+LABEL maintainer="Sebastian Mandrean <sebastian.mandrean@gmail.com>"
+
+# Environment variables
+ENV GOOS linux
+ENV GOARCH amd64
+ENV CGO_ENABLED 0
+
+ENV ALPINE_MIRROR http://dl-3.alpinelinux.org/alpine
+
+# Install dependencies
+RUN printf "@community ${ALPINE_MIRROR}/edge/community/" >> "/etc/apk/repositories" && \
+	apk --no-cache add \
+		git \
+		curl \
+		upx@community && \
+	apk --no-cache del wget
+
+ADD entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+WORKDIR /go/src

--- a/shrink-go/README.md
+++ b/shrink-go/README.md
@@ -1,0 +1,32 @@
+mandrean/shrink-go
+==================
+Compiles, strips and compresses statically linked Go binaries into their smallest possible size.
+
+Based on go1.9 and Alpine 3.6.
+
+Pre-requisites
+--------------
+* [Docker](https://docs.docker.com/engine/installation/)
+
+Usage
+-----
+Send your Go project import path as the only argument to the build container, and mount your `GOPATH` or Go project into it:
+
+```sh
+docker run --rm -it \
+	-v $(GOPATH):/go \
+	mandrean/shrink-go \
+	github.com/your-name/your-project
+```
+
+Or just the Go project it self:
+```sh
+docker run --rm -it \
+	-v ~/go/src/github.com/your-name/your-project:/go/src/github.com/your-name/your-project \
+	mandrean/shrink-go \
+	github.com/your-name/your-project
+```
+
+Maintainers
+-----------
+* Sebastian Mandrean (<sebastian.mandrean@gmail.com>)

--- a/shrink-go/entrypoint.sh
+++ b/shrink-go/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+PROJ=$1
+
+printf "\nInitiating shrink-go for $PROJ... "
+cd $PROJ
+if [ $? -ne 0 ]; then
+    echo -e "ERROR: Couldn't find $GOPATH/src/$PROJ"
+    echo -e "Aborting."
+    exit 1
+fi
+printf "Done.\n"
+
+printf "Building statically linked binary with stripped symbols... "
+go build -a -installsuffix cgo -ldflags="-s -w"
+if [ $? -ne 0 ]; then
+    echo -e "ERROR: Couldn't build $PROJ"
+    echo -e "Aborting."
+    exit 1
+fi
+printf "Done.\n"
+
+
+printf "Packing with upx...\n"
+DIR=$(basename "$PWD")
+upx -f --best --ultra-brute -o $DIR-upx $DIR
+if [ $? -ne 0 ]; then
+    echo -e "ERROR: Couldn't pack $PROJ with upx"
+    echo -e "Aborting."
+    exit 1
+fi
+
+echo "Successfully shrinked $PROJ!"
+echo "Done."


### PR DESCRIPTION
Build image for compiling & shrinking statically linked Go binaries into their smallest possible size.